### PR TITLE
Configure Renovate with automerge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "rangeStrategy": "update-lockfile",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Renovate configuration that extends the base preset and enables platform auto-merge for non-major updates

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68f4a409bf7c83289f05b3f2b8eb9565